### PR TITLE
Add highlight group for TSTagDelimiter

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -324,6 +324,7 @@ highlight! link TSRepeat Purple
 highlight! link TSLabel Purple
 highlight! link TSOperator Purple
 highlight! link TSKeyword Purple
+highlight! link TSTagDelimiter Purple
 highlight! link TSException Purple
 highlight! link TSType RedItalic
 highlight! link TSTypeBuiltin RedItalic


### PR DESCRIPTION
This adds a highlight group for `TSTagDelimiter`. Without this, React/JSX tags are not highlighted:

![image](https://user-images.githubusercontent.com/2834949/100136365-405b7700-2e8b-11eb-8c81-732ba10c1a2a.png)

A couple of other TS highlight groups I saw in another scheme that are missing from yours are these two:
[`TSVariable`](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/doc/nvim-treesitter.txt#L572)
[`TSVariableBuiltin`](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/doc/nvim-treesitter.txt#L576)

And thanks for the awesome work with your color schemes. They're the best ones around imo :)