### PR TITLE
feat(plugin): support hop.nvim

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -718,6 +718,12 @@ highlight! link Sneak Search
 highlight! link SneakLabel Search
 highlight! link SneakScope DiffText
 " }}}
+" phaazon/hop.nvim {{{
+call edge#highlight('HopNextKey', s:palette.purple, s:palette.none, 'bold')
+call edge#highlight('HopNextKey1', s:palette.blue, s:palette.none, 'bold')
+call edge#highlight('HopNextKey2', s:palette.blue, s:palette.none)
+call edge#highlight('HopUnmatched', s:palette.grey, s:palette.none)
+" }}}
 " terryma/vim-multiple-cursors {{{
 highlight! link multiple_cursors_cursor Cursor
 highlight! link multiple_cursors_visual Visual


### PR DESCRIPTION
Add support for [`hop.nvim`](https://github.com/phaazon/hop.nvim). 

Looks like this (not sure if these are the best colors, feel free to change them!):

![hop nvim](https://user-images.githubusercontent.com/2834949/130962561-4db38069-4387-4133-9f2d-a233a3fcfc63.gif)