### PR TITLE
link CocSem_property to TSProperty instead of TSVariable

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -436,7 +436,7 @@ highlight! link CocSem_number TSNumber
 highlight! link CocSem_operator TSOperator
 highlight! link CocSem_parameter TSParameter
 highlight! link CocSem_parenthesis TSPunctBracket
-highlight! link CocSem_property TSVariable
+highlight! link CocSem_property TSProperty
 highlight! link CocSem_punctuation TSOperator
 highlight! link CocSem_regexp TSStringRegex
 highlight! link CocSem_selfKeyword TSConstBuiltin


### PR DESCRIPTION
Obviously CocSem_property should link to TSProperty, is it a typo?