### PR TITLE
Make TSEmphasis italic

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -344,7 +344,7 @@ endif
 " Plugins: {{{
 " nvim-treesitter/nvim-treesitter {{{
 call edge#highlight('TSStrong', s:palette.none, s:palette.none, 'bold')
-call edge#highlight('TSEmphasis', s:palette.none, s:palette.none, 'bold')
+call edge#highlight('TSEmphasis', s:palette.none, s:palette.none, 'italic')
 call edge#highlight('TSUnderline', s:palette.none, s:palette.none, 'underline')
 call edge#highlight('TSNote', s:palette.bg0, s:palette.blue, 'bold')
 call edge#highlight('TSWarning', s:palette.bg0, s:palette.yellow, 'bold')


### PR DESCRIPTION
Emphasis is usually italic, and TSEmphasis is used by treesitter for italics in markdown.

![image](https://user-images.githubusercontent.com/3298461/148141518-cf5e79fc-2767-4fca-bc1d-151c65784ed1.png)
