### PR TITLE
Fix fern marking

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -1097,7 +1097,7 @@ highlight! link NvimTreeLspDiagnosticsHint GreenSign
 " syn_end }}}
 " syn_begin: fern {{{
 " https://github.com/lambdalisue/fern.vim
-highlight! link FernMarkedLine None
+highlight! link FernMarkedLine Purple
 highlight! link FernMarkedText Purple
 highlight! link FernRootSymbol FernRootText
 highlight! link FernRootText Blue


### PR DESCRIPTION
Fern marked lines are currently invisible. Adding a highlight makes selected files visible and easier to work with.

## After screenshots
![Screen Shot 2022-04-25 at 4 01 36 PM](https://user-images.githubusercontent.com/24086/165165852-45e53c00-b867-44d2-8e15-2ab6e28e9209.png)
![Screen Shot 2022-04-25 at 4 01 46 PM](https://user-images.githubusercontent.com/24086/165165854-b9683929-7fcb-45e5-b5f9-a557ac84709f.png)
