### PR TITLE
feat(plugin): optimize `echasnovski/mini.nvim`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add `g:edge_dim_foreground`.
 - Optimize `b0o/incline.nvim`.
 - Optimize winbar.
+- Optimize `echasnovski/mini.nvim`.
 
 ## [0.2.2] - 2022-05-26
 

--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -924,6 +924,57 @@ highlight! link TargetFileName Grey
 " b0o/incline.nvim {{{
 call edge#highlight('InclineNormalNC', s:palette.grey, s:palette.bg2)
 " }}}
+" echasnovski/mini.nvim {{{
+highlight! link MiniCompletionActiveParameter LspSignatureActiveParameter
+
+highlight! link MiniCursorword CurrentWord
+highlight! link MiniCursorwordCurrent CurrentWord
+
+highlight! link MiniIndentscopeSymbol Grey
+call edge#highlight('MiniIndentscopePrefix', s:palette.none, s:palette.none, 'nocombine') " Make it invisible
+
+highlight! link MiniJump Search
+
+call edge#highlight('MiniJump2dSpot', s:palette.purple, s:palette.none, 'bold,nocombine')
+
+call edge#highlight('MiniStarterCurrent', s:palette.none, s:palette.none, 'nocombine')
+highlight! link MiniStarterFooter Red
+highlight! link MiniStarterHeader Purple
+highlight! link MiniStarterInactive Comment
+highlight! link MiniStarterItem Normal
+call edge#highlight('MiniStarterItemBullet', s:palette.grey, s:palette.none)
+call edge#highlight('MiniStarterItemPrefix', s:palette.yellow, s:palette.none)
+highlight! link MiniStarterSection Title
+call edge#highlight('MiniStarterQuery', s:palette.blue, s:palette.none)
+
+call edge#highlight('MiniStatuslineDevinfo', s:palette.fg, s:palette.bg2)
+call edge#highlight('MiniStatuslineFileinfo', s:palette.fg, s:palette.bg2)
+call edge#highlight('MiniStatuslineFilename', s:palette.grey, s:palette.bg1)
+call edge#highlight('MiniStatuslineModeInactive', s:palette.grey, s:palette.bg1)
+call edge#highlight('MiniStatuslineModeCommand', s:palette.bg0, s:palette.bg_green, 'bold')
+call edge#highlight('MiniStatuslineModeInsert', s:palette.bg0, s:palette.bg_blue, 'bold')
+call edge#highlight('MiniStatuslineModeNormal', s:palette.bg0, s:palette.bg_purple, 'bold')
+call edge#highlight('MiniStatuslineModeOther', s:palette.bg0, s:palette.cyan, 'bold')
+call edge#highlight('MiniStatuslineModeReplace', s:palette.bg0, s:palette.yellow, 'bold')
+call edge#highlight('MiniStatuslineModeVisual', s:palette.bg0, s:palette.bg_red, 'bold')
+
+highlight! link MiniSurround IncSearch
+
+call edge#highlight('MiniTablineCurrent', s:palette.fg, s:palette.bg4)
+highlight! link MiniTablineFill TabLineFill
+call edge#highlight('MiniTablineHidden', s:palette.grey, s:palette.bg2)
+call edge#highlight('MiniTablineModifiedCurrent', s:palette.blue, s:palette.bg4)
+call edge#highlight('MiniTablineModifiedHidden', s:palette.grey, s:palette.bg2)
+call edge#highlight('MiniTablineModifiedVisible', s:palette.blue, s:palette.bg2)
+call edge#highlight('MiniTablineTabpagesection', s:palette.bg0, s:palette.blue, 'bold')
+call edge#highlight('MiniTablineVisible', s:palette.fg, s:palette.bg2)
+
+call edge#highlight('MiniTestEmphasis', s:palette.none, s:palette.none, 'bold')
+call edge#highlight('MiniTestFail', s:palette.red, s:palette.none, 'bold')
+call edge#highlight('MiniTestPass', s:palette.green, s:palette.none, 'bold')
+
+call edge#highlight('MiniTrailspace', s:palette.none, s:palette.red)
+" }}}
 endif
 " }}}
 " Extended File Types: {{{


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Logic of highlight groups and their effect are same as in sainnhe/everforest#69.