### PR TITLE
fix(tree-sitter): TSTypeDefinition -> Yellow

### DIFF
--- a/colors/edge.vim
+++ b/colors/edge.vim
@@ -452,7 +452,7 @@ highlight! link TSTitle Title
 highlight! link TSTodo Todo
 highlight! link TSType Yellow
 highlight! link TSTypeBuiltin Yellow
-highlight! link TSTypeDefinition Purple
+highlight! link TSTypeDefinition Yellow
 highlight! link TSTypeQualifier Purple
 highlight! link TSURI markdownUrl
 highlight! link TSVariable RedItalic


### PR DESCRIPTION
Based on how `@type.definition` is used in `nvim-treesitter`, `TSTypeDefinition` should be the same color as `TSType`.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/210156451-b4d39313-f2f5-412e-8a58-5d9cdaae70a7.png) | ![image](https://user-images.githubusercontent.com/4299733/210156465-b564ea5a-7422-474a-b242-cf01a6fc95b0.png) |